### PR TITLE
Mods to make swap router transpilable

### DIFF
--- a/contracts/base/PeripheryPayments.sol
+++ b/contracts/base/PeripheryPayments.sol
@@ -11,10 +11,7 @@ import '../libraries/TransferHelper.sol';
 import './PeripheryImmutableState.sol';
 
 abstract contract PeripheryPayments is IPeripheryPayments, PeripheryImmutableState {
-    receive() external payable {
-        require(msg.sender == WETH9, 'Not WETH9');
-    }
-
+    /*
     /// @inheritdoc IPeripheryPayments
     function unwrapWETH9(uint256 amountMinimum, address recipient) public payable override {
         uint256 balanceWETH9 = IWETH9(WETH9).balanceOf(address(this));
@@ -25,6 +22,7 @@ abstract contract PeripheryPayments is IPeripheryPayments, PeripheryImmutableSta
             TransferHelper.safeTransferETH(recipient, balanceWETH9);
         }
     }
+     */
 
     /// @inheritdoc IPeripheryPayments
     function sweepToken(
@@ -40,10 +38,12 @@ abstract contract PeripheryPayments is IPeripheryPayments, PeripheryImmutableSta
         }
     }
 
+    /*
     /// @inheritdoc IPeripheryPayments
     function refundETH() external payable override {
         if (address(this).balance > 0) TransferHelper.safeTransferETH(msg.sender, address(this).balance);
     }
+     */
 
     /// @param token The token to pay
     /// @param payer The entity that must pay
@@ -55,9 +55,9 @@ abstract contract PeripheryPayments is IPeripheryPayments, PeripheryImmutableSta
         address recipient,
         uint256 value
     ) internal {
-        if (token == WETH9 && address(this).balance >= value) {
+        if (token == WETH9 && IWETH9(WETH9).balanceOf(address(this)) >= value) {
             // pay with WETH9
-            IWETH9(WETH9).deposit{value: value}(); // wrap only what is needed to pay
+            // IWETH9(WETH9).deposit{value: value}(); // wrap only what is needed to pay
             IWETH9(WETH9).transfer(recipient, value);
         } else if (payer == address(this)) {
             // pay with tokens already in the contract (for the exact input multihop case)

--- a/contracts/base/PeripheryPaymentsWithFee.sol
+++ b/contracts/base/PeripheryPaymentsWithFee.sol
@@ -13,6 +13,7 @@ import '../libraries/TransferHelper.sol';
 abstract contract PeripheryPaymentsWithFee is PeripheryPayments, IPeripheryPaymentsWithFee {
     using LowGasSafeMath for uint256;
 
+    /*
     /// @inheritdoc IPeripheryPaymentsWithFee
     function unwrapWETH9WithFee(
         uint256 amountMinimum,
@@ -32,6 +33,7 @@ abstract contract PeripheryPaymentsWithFee is PeripheryPayments, IPeripheryPayme
             TransferHelper.safeTransferETH(recipient, balanceWETH9 - feeAmount);
         }
     }
+     */
 
     /// @inheritdoc IPeripheryPaymentsWithFee
     function sweepTokenWithFee(
@@ -47,7 +49,7 @@ abstract contract PeripheryPaymentsWithFee is PeripheryPayments, IPeripheryPayme
         require(balanceToken >= amountMinimum, 'Insufficient token');
 
         if (balanceToken > 0) {
-            uint256 feeAmount = balanceToken.mul(feeBips) / 10_000;
+            uint256 feeAmount = balanceToken.mul(feeBips) / 10000;
             if (feeAmount > 0) TransferHelper.safeTransfer(token, feeRecipient, feeAmount);
             TransferHelper.safeTransfer(token, recipient, balanceToken - feeAmount);
         }

--- a/contracts/interfaces/IPeripheryPayments.sol
+++ b/contracts/interfaces/IPeripheryPayments.sol
@@ -4,16 +4,20 @@ pragma solidity ^0.8.14;
 /// @title Periphery Payments
 /// @notice Functions to ease deposits and withdrawals of ETH
 interface IPeripheryPayments {
+    /*
     /// @notice Unwraps the contract's WETH9 balance and sends it to recipient as ETH.
     /// @dev The amountMinimum parameter prevents malicious contracts from stealing WETH9 from users.
     /// @param amountMinimum The minimum amount of WETH9 to unwrap
     /// @param recipient The address receiving ETH
     function unwrapWETH9(uint256 amountMinimum, address recipient) external payable;
+     */
 
+    /*
     /// @notice Refunds any ETH balance held by this contract to the `msg.sender`
     /// @dev Useful for bundling with mint or increase liquidity that uses ether, or exact output swaps
     /// that use ether for the input amount
     function refundETH() external payable;
+     */
 
     /// @notice Transfers the full amount of a token held by this contract to recipient
     /// @dev The amountMinimum parameter prevents malicious contracts from stealing the token from users

--- a/contracts/interfaces/IPeripheryPaymentsWithFee.sol
+++ b/contracts/interfaces/IPeripheryPaymentsWithFee.sol
@@ -6,6 +6,7 @@ import './IPeripheryPayments.sol';
 /// @title Periphery Payments
 /// @notice Functions to ease deposits and withdrawals of ETH
 interface IPeripheryPaymentsWithFee is IPeripheryPayments {
+    /*
     /// @notice Unwraps the contract's WETH9 balance and sends it to recipient as ETH, with a percentage between
     /// 0 (exclusive), and 1 (inclusive) going to feeRecipient
     /// @dev The amountMinimum parameter prevents malicious contracts from stealing WETH9 from users.
@@ -15,6 +16,7 @@ interface IPeripheryPaymentsWithFee is IPeripheryPayments {
         uint256 feeBips,
         address feeRecipient
     ) external payable;
+     */
 
     /// @notice Transfers the full amount of a token held by this contract to recipient, with a percentage between
     /// 0 (exclusive) and 1 (inclusive) going to feeRecipient

--- a/contracts/interfaces/ISwapRouter.sol
+++ b/contracts/interfaces/ISwapRouter.sol
@@ -31,10 +31,13 @@ interface ISwapRouter is IUniswapV3SwapCallback {
         uint256 amountOutMinimum;
     }
 
+
+    // Swapped ExactInputParams struct for it's definition, because nested types
+    // (struct and bytes) are not allowed
     /// @notice Swaps `amountIn` of one token for as much as possible of another along the specified path
-    /// @param params The parameters necessary for the multi-hop swap, encoded as `ExactInputParams` in calldata
+    /// param params The parameters necessary for the multi-hop swap, encoded as `ExactInputParams` in calldata
     /// @return amountOut The amount of the received token
-    function exactInput(ExactInputParams calldata params) external payable returns (uint256 amountOut);
+    function exactInput(bytes calldata path, address recipient, uint256 deadline, uint256 amountIn, uint256 amountOutMinimum) external payable returns (uint256 amountOut);
 
     struct ExactOutputSingleParams {
         address tokenIn;
@@ -61,7 +64,7 @@ interface ISwapRouter is IUniswapV3SwapCallback {
     }
 
     /// @notice Swaps as little as possible of one token for `amountOut` of another along the specified path (reversed)
-    /// @param params The parameters necessary for the multi-hop swap, encoded as `ExactOutputParams` in calldata
+    /// param params The parameters necessary for the multi-hop swap, encoded as `ExactOutputParams` in calldata
     /// @return amountIn The amount of the input token
-    function exactOutput(ExactOutputParams calldata params) external payable returns (uint256 amountIn);
+    function exactOutput(bytes calldata path, address recipient, uint256 deadline, uint256 amountOut, uint256 amountInMaximum) external payable returns (uint256 amountIn);
 }

--- a/contracts/libraries/BytesLib.sol
+++ b/contracts/libraries/BytesLib.sol
@@ -20,6 +20,12 @@ library BytesLib {
 
         bytes memory tempBytes;
 
+        tempBytes = new bytes(_length);
+        for (uint256 i = 0; i < _length; i++) {
+            tempBytes[i] = _bytes[_start + i];
+        }
+
+        /*
         assembly {
             switch iszero(_length)
                 case 0 {
@@ -71,18 +77,27 @@ library BytesLib {
                     mstore(0x40, add(tempBytes, 0x20))
                 }
         }
+         */
 
         return tempBytes;
     }
 
     function toAddress(bytes memory _bytes, uint256 _start) internal pure returns (address) {
-        require(_start + 20 >= _start, 'toAddress_overflow');
-        require(_bytes.length >= _start + 20, 'toAddress_outOfBounds');
-        address tempAddress;
+        require(_start + 32 >= _start, 'toAddress_overflow');
+        require(_bytes.length >= _start + 32, 'toAddress_outOfBounds');
 
+        bytes memory tempBytes = new bytes(32);
+        for (uint256 i = 0; i < _start + 32; i++) {
+            tempBytes[i] = _bytes[_start + i];
+        }
+
+        address tempAddress;
+        tempAddress = address(bytes32(tempBytes));
+        /*
         assembly {
             tempAddress := div(mload(add(add(_bytes, 0x20), _start)), 0x1000000000000000000000000)
         }
+         */
 
         return tempAddress;
     }
@@ -90,11 +105,20 @@ library BytesLib {
     function toUint24(bytes memory _bytes, uint256 _start) internal pure returns (uint24) {
         require(_start + 3 >= _start, 'toUint24_overflow');
         require(_bytes.length >= _start + 3, 'toUint24_outOfBounds');
-        uint24 tempUint;
 
+        bytes memory tempBytes = new bytes(3);
+        for (uint256 i = 0; i < _start + 3; i++) {
+            tempBytes[i] = _bytes[_start + i];
+        }
+
+        uint24 tempUint;
+        tempUint = uint24(bytes3(tempBytes));
+
+        /*
         assembly {
             tempUint := mload(add(add(_bytes, 0x3), _start))
         }
+         */
 
         return tempUint;
     }

--- a/contracts/libraries/TransferHelper.sol
+++ b/contracts/libraries/TransferHelper.sol
@@ -16,9 +16,13 @@ library TransferHelper {
         address to,
         uint256 value
     ) internal {
+        bool success = IERC20(token).transferFrom(from, to, value);
+        require(success, 'STF');
+        /*
         (bool success, bytes memory data) =
             token.call(abi.encodeWithSelector(IERC20.transferFrom.selector, from, to, value));
         require(success && (data.length == 0 || abi.decode(data, (bool))), 'STF');
+         */
     }
 
     /// @notice Transfers tokens from msg.sender to a recipient
@@ -31,8 +35,12 @@ library TransferHelper {
         address to,
         uint256 value
     ) internal {
+        bool success = IERC20(token).transfer( to, value);
+        require(success, 'ST');
+        /*
         (bool success, bytes memory data) = token.call(abi.encodeWithSelector(IERC20.transfer.selector, to, value));
         require(success && (data.length == 0 || abi.decode(data, (bool))), 'ST');
+         */
     }
 
     /// @notice Approves the stipulated contract to spend the given allowance in the given token
@@ -45,10 +53,15 @@ library TransferHelper {
         address to,
         uint256 value
     ) internal {
+        bool success = IERC20(token).approve( to, value);
+        require(success, 'SA');
+        /*
         (bool success, bytes memory data) = token.call(abi.encodeWithSelector(IERC20.approve.selector, to, value));
         require(success && (data.length == 0 || abi.decode(data, (bool))), 'SA');
+         */
     }
 
+    /*
     /// @notice Transfers ETH to the recipient address
     /// @dev Fails with `STE`
     /// @param to The destination of the transfer
@@ -57,4 +70,5 @@ library TransferHelper {
         (bool success, ) = to.call{value: value}(new bytes(0));
         require(success, 'STE');
     }
+     */
 }


### PR DESCRIPTION
Changes:
* De-struct (Make it tuples) two struct that had an array inside, and we don't support nested reference types calldata.
* Restrict tokens multicall ability (because it used nested references as calldata)
* Replaced all address `call`s for interface calls
* Changed payment mechanics to work with Weth